### PR TITLE
Update Google Selector to work now that parent div is getting removed

### DIFF
--- a/src/js/meeting_clients/google_meet.js
+++ b/src/js/meeting_clients/google_meet.js
@@ -8,19 +8,12 @@ export class GoogleMeet extends Clients {
     }
 
     getStatus() {
-        let oldMuteButton = getElement("[data-is-muted] div");
-        let newMuteButton = getElement("[data-is-muted] button");
+        let newMuteButton = getElement("[data-is-muted]");
         let videoButton = (
             getElement('[aria-label="Turn off camera (ctrl + e)"]') || 
             getElement('[aria-label="Turn on camera (ctrl + e)"]')
         );
-        let status = ''
-
-        if(muteStatus(oldMuteButton, "data-is-muted") != 'disabled'){
-            status += `chromeMute:${muteStatus(oldMuteButton, "data-is-muted")},`
-        }else{
-            status += `chromeMute:${muteStatus(newMuteButton, "data-is-muted")},`
-        }
+        let status = `chromeMute:${muteStatus(newMuteButton, "data-is-muted")},`
 
         if(videoButton){
             videoButton = videoButton.getAttribute("data-is-muted") == "true" ? "stopped" : "started";
@@ -33,18 +26,13 @@ export class GoogleMeet extends Clients {
     }
 
     toggleMute() {
-        let oldMuteButton = getElement("[data-is-muted] div");
-        let newMuteButton = getElement("[data-is-muted] button");
+        let newMuteButton = getElement("[data-is-muted]");
 
-        if(!oldMuteButton && !newMuteButton){
+        if(!newMuteButton){
             return "chromeMute:disabled"
         }
-        
-        if(muteStatus(oldMuteButton, "data-is-muted") != 'disabled'){
-            oldMuteButton.click();
-        }else{
-            newMuteButton.click();
-        }
+
+        newMuteButton.click();
     }
 
     toggleVideo() {


### PR DESCRIPTION
## Problem: 

The Google Meet selector is using a selector for an outer `div` (`data-is-muted`) that is now pretty outdated. Recently, I've had a few calls in my Workspace account where the older outer `data-is-muted` `div` was removed (the `data-is-muted` `button` is still there though).

The absence of the parent `data-is-muted` `div` now prevents the extension from functioning on my Workspace account calls. I think the missing element (since it is checked first) is causing the extension to crash when it looks for it, which is why it stopped working for me. 

## Solution:

The removal of the legacy selector fixes the problem. 

I have tested this on both my personal (where the outer `data-is-muted` div is still present) and my workspace account (where the outer `data-is-muted` div has been removed). Both are working with my PR.

Thanks!